### PR TITLE
Fix #6 - RangerEdit inside split in neovim (second attempt)

### DIFF
--- a/plugin/ranger.vim
+++ b/plugin/ranger.vim
@@ -30,7 +30,15 @@ endfunction
 function! s:RangerNVim(opts)
   let rangerCallback = { 'name': 'ranger' }
   function! rangerCallback.on_exit(id, code, _event)
-    silent! bdelete!
+    if g:ranger_layout != 'edit'
+      silent! bdelete!
+    else
+      if bufnr('%') != bufnr('#')
+        setl bufhidden=delete | buffer! #
+      else
+        enew | bdelete! #
+      endif
+    endif
     call s:HandleRangerOutput()
   endfunction
 
@@ -109,11 +117,7 @@ endfunction
 "----------------------------------------------}}}
 function! s:Ranger(path) " {{{
   " Open a new layout at a path to start ranger
-  if has('nvim') && (g:ranger_layout == 'edit')
-    exec 'tabedit! ' . a:path
-  else
-    exec g:ranger_layout . '! ' . a:path
-  endif
+  exec g:ranger_layout . '! ' . a:path
 endfunction
 
 "----------------------------------------------}}}


### PR DESCRIPTION
This MR modifies the plugin so RangerEdit opens ranger within the current split
instead of forcing a new tab.

This second attempt fixes the issue when closing Ranger without selecting any files in both vim and neovim.